### PR TITLE
Update rn-salesforce-chat.podspec

### DIFF
--- a/rn-salesforce-chat.podspec
+++ b/rn-salesforce-chat.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "rn-salesforce-chat"
+  s.name         = package['name'].sub(/^@loadsmart\//, '')
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']


### PR DESCRIPTION
Just in case we decide to rename the package and we don't accidentally forget to update the name on the podspec file.