### PR TITLE
Chore/ set visitor name

### DIFF
--- a/android/src/main/java/com/rn/salesforce/chat/RNSalesforceChatModule.java
+++ b/android/src/main/java/com/rn/salesforce/chat/RNSalesforceChatModule.java
@@ -134,8 +134,10 @@ public class RNSalesforceChatModule extends ReactContextBaseJavaModule implement
 	}
 
 	@ReactMethod
-	public void configureChat(String orgId, String buttonId, String deploymentId, String liveAgentPod) {
+	public void configureChat(String orgId, String buttonId, String deploymentId, String liveAgentPod, @Nullable String visitorName) {
 		ChatConfiguration.Builder chatConfigurationBuilder = new ChatConfiguration.Builder(orgId, buttonId, deploymentId, liveAgentPod);
+
+		if (visitorName != null) chatConfigurationBuilder.visitorName(visitorName);
 
 		ChatConfiguration chatConfiguration = chatConfigurationBuilder
 				.chatUserData(new ArrayList<>(chatUserDataMap.values()))

--- a/ios/RNSalesforceChat.m
+++ b/ios/RNSalesforceChat.m
@@ -100,10 +100,12 @@ RCT_EXPORT_METHOD(createEntity:(NSString *)objectType linkToTranscriptField:(NSS
 }
 
 RCT_EXPORT_METHOD(configureChat:(NSString *)orgId buttonId:(NSString *)buttonId deploymentId:(NSString *)deploymentId
-                  liveAgentPod:(NSString *)liveAgentPod)
+                  liveAgentPod:(NSString *)liveAgentPod visitorName:(NSString *)visitorName)
 {
     chatConfiguration = [[SCSChatConfiguration alloc] initWithLiveAgentPod:liveAgentPod orgId:orgId
                                                               deploymentId:deploymentId buttonId:buttonId];
+
+    if (visitorName != nil) chatConfiguration.visitorName = visitorName;
     chatConfiguration.prechatFields = [prechatFields allValues];
     chatConfiguration.prechatEntities = entities;
 }

--- a/lib/api/__tests__/salesforceChatAPI.test.js
+++ b/lib/api/__tests__/salesforceChatAPI.test.js
@@ -50,6 +50,7 @@ describe("SalesforceChatAPI", () => {
       buttonId: "someButtonId",
       deploymentId: "someDeploymentId",
       liveAgentPod: "someLiveAgentPod",
+      visitorName: "Some Name",
     };
   });
 
@@ -228,7 +229,8 @@ describe("SalesforceChatAPI", () => {
         "someOrgId",
         "someButtonId",
         "someDeploymentId",
-        "someLiveAgentPod"
+        "someLiveAgentPod",
+        "Some Name"
       );
     });
 

--- a/lib/api/interfaces/ChatConfig.ts
+++ b/lib/api/interfaces/ChatConfig.ts
@@ -3,4 +3,5 @@ export interface ChatConfig {
   buttonId: string;
   deploymentId: string;
   liveAgentPod: string;
+  visitorName: string | undefined;
 }

--- a/lib/api/salesforceChatAPI.js
+++ b/lib/api/salesforceChatAPI.js
@@ -74,7 +74,13 @@ export default class SalesforceChatAPI {
     );
   }
 
-  async configureChat({ orgId, buttonId, deploymentId, liveAgentPod }) {
+  async configureChat({
+    orgId,
+    buttonId,
+    deploymentId,
+    liveAgentPod,
+    visitorName,
+  }) {
     if (!orgId) this.throwRequiredFieldError("orgId");
     if (!buttonId) this.throwRequiredFieldError("buttonId");
     if (!deploymentId) this.throwRequiredFieldError("deploymentId");
@@ -84,7 +90,8 @@ export default class SalesforceChatAPI {
       orgId,
       buttonId,
       deploymentId,
-      liveAgentPod
+      liveAgentPod,
+      visitorName
     );
   }
 


### PR DESCRIPTION
## Types of changes

- New feature
- Unit tests
- Refactoring

## Description of the proposed changes

- Modifies `configureChat` method to accept a `visitorName` param that will be used to set the visitor's name on the Salesforce live chat.
