### PR TITLE
Bugfix: Missing native modules in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "lib": "lib"
   },
   "files": [
-    "lib"
+    "lib",
+    "ios",
+    "android",
+    "rn-salesforce-chat.podspec"
   ],
   "keywords": [
     "react-native",


### PR DESCRIPTION
## Change and Reason

Bugfix - https://github.com/loadsmart/rn-salesforce-chat/issues/16

## Description of the proposed changes

Updated `files` property in package.json with `ios`, `android` folders and `rn-salesforce-chat.podspec` file to be included in the published package.
