### PR TITLE
Fix EntityField objects being overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,42 +115,49 @@ export default async function startSalesforceChat() {
 
   const salesforceApi = new SalesforceChatAPI()
 
-  const firstName = 'First Name'
-  const lastName = 'Last Name'
+  const PRE_CHAT_FIRST_NAME_KEY = "pre_chat_first_name_key"
+  const PRE_CHAT_LAST_NAME_KEY = "pre_chat_last_name_key"
+
+  const ENTITY_FIELD_FIRST_NAME_KEY = "entity_field_first_name_key"
+  const ENTITY_FIELD_LAST_NAME_KEY = "entity_field_last_name_key"
 		
   // creating pre chat data objects:
   const createPreChatData = async () => {
     salesforceApi.createPreChatData({
-      agentLabel: firstName,
+      agentLabel: "First Name",
       value: "Some First Name",
       isDisplayedToAgent: true,
       transcriptFields: ["some transcript field"]
+      preChatDataKey: PRE_CHAT_FIRST_NAME_KEY
     })
 
     salesforceApi.createPreChatData({
-      agentLabel: lastName,
+      agentLabel: "Last Name",
       value: "Some Last Name",
       isDisplayedToAgent: true,
       transcriptFields: ["some transcript field"]
+      preChatDataKey: PRE_CHAT_LAST_NAME_KEY
     })
   }
 
   // creating entity field objects:
   const createEntityFields = async () => {
     salesforceApi.createEntityField({
-      objectFieldName: firstName,
+      objectFieldName: "First Name",
       doCreate: false,
       doFind: true,
       isExactMatch: false,
-      keyChatUserDataToMap: firstName,
+      preChatDataKeyToMap: PRE_CHAT_FIRST_NAME_KEY,
+      entityFieldKey: ENTITY_FIELD_FIRST_NAME_KEY
     })
 
     salesforceApi.createEntityField({
-      objectFieldName: lastName,
+      objectFieldName: "Last Name",
       doCreate: false,
       doFind: true,
       isExactMatch: false,
-      keyChatUserDataToMap: lastName,
+      preChatDataKeyToMap: PRE_CHAT_LAST_NAME_KEY,
+      entityFieldKey: ENTITY_FIELD_LAST_NAME_KEY
     })
   }
 
@@ -160,7 +167,7 @@ export default async function startSalesforceChat() {
       objectType: 'Contact',
       linkToTranscriptField: 'ContactId',
       showOnCreate: true,
-      keysEntityFieldToMap: [firstName, lastName],
+      entityFieldKeysToMap: [ENTITY_FIELD_FIRST_NAME_KEY, ENTITY_FIELD_LAST_NAME_KEY],
     })
   }
 

--- a/android/src/main/java/com/rn/salesforce/chat/RNSalesforceChatModule.java
+++ b/android/src/main/java/com/rn/salesforce/chat/RNSalesforceChatModule.java
@@ -83,7 +83,7 @@ public class RNSalesforceChatModule extends ReactContextBaseJavaModule implement
 	}
 
 	@ReactMethod
-	public void createPreChatData(String agentLabel, @Nullable String value, Boolean isDisplayedToAgent, @Nullable ReadableArray transcriptFields) {
+	public void createPreChatData(String agentLabel, @Nullable String value, Boolean isDisplayedToAgent, @Nullable ReadableArray transcriptFields, String preChatDataKey) {
 		ArrayList<String> tempTranscriptFields = new ArrayList<>();
 
 		if (transcriptFields != null) {
@@ -94,26 +94,25 @@ public class RNSalesforceChatModule extends ReactContextBaseJavaModule implement
 		String[] receivedTranscriptFields = tempTranscriptFields.toArray(new String[0]);
 
 		if (value != null) {
-			chatUserDataMap.put(agentLabel, new ChatUserData(agentLabel, value, isDisplayedToAgent, receivedTranscriptFields));
+			chatUserDataMap.put(preChatDataKey, new ChatUserData(agentLabel, value, isDisplayedToAgent, receivedTranscriptFields));
 		} else {
-			chatUserDataMap.put(agentLabel, new ChatUserData(agentLabel, isDisplayedToAgent, receivedTranscriptFields));
+			chatUserDataMap.put(preChatDataKey, new ChatUserData(agentLabel, isDisplayedToAgent, receivedTranscriptFields));
 		}
 	}
 
 	@ReactMethod
-	public void createEntityField(String objectFieldName, Boolean doCreate, Boolean doFind, Boolean isExactMatch, @Nullable String keyChatUserDataToMap) {
-		if (chatUserDataMap.containsKey(keyChatUserDataToMap)) {
-			chatEntityFieldMap.put(objectFieldName, new ChatEntityField.Builder()
+	public void createEntityField(String objectFieldName, Boolean doCreate, Boolean doFind, Boolean isExactMatch, @Nullable String preChatDataKeyToMap, String entityFieldKey) {
+		if (chatUserDataMap.containsKey(preChatDataKeyToMap)) {
+			chatEntityFieldMap.put(entityFieldKey, new ChatEntityField.Builder()
 					.doCreate(doCreate)
 					.doFind(doFind)
 					.isExactMatch(isExactMatch)
-					.build(objectFieldName, Objects.requireNonNull(chatUserDataMap.get(keyChatUserDataToMap)))
-			);
+					.build(objectFieldName, Objects.requireNonNull(chatUserDataMap.get(preChatDataKeyToMap))));
 		}
 	}
 
 	@ReactMethod
-	public void createEntity(String objectType, @Nullable String linkToTranscriptField, Boolean showOnCreate, @Nullable ReadableArray keysEntityFieldToMap) {
+	public void createEntity(String objectType, @Nullable String linkToTranscriptField, Boolean showOnCreate, @Nullable ReadableArray entityFieldKeysToMap) {
 		ChatEntity entity;
 
 		if (linkToTranscriptField != null) {
@@ -127,9 +126,9 @@ public class RNSalesforceChatModule extends ReactContextBaseJavaModule implement
 					.build(objectType);
 		}
 
-		if (keysEntityFieldToMap != null) {
-			for (int i = 0; i < keysEntityFieldToMap.size(); i++) {
-				String key = keysEntityFieldToMap.getString(i);
+		if (entityFieldKeysToMap != null) {
+			for (int i = 0; i < entityFieldKeysToMap.size(); i++) {
+				String key = entityFieldKeysToMap.getString(i);
 				if (chatEntityFieldMap.containsKey(key)) {
 					entity.getChatEntityFields().add(chatEntityFieldMap.get(key));
 				}

--- a/ios/RNSalesforceChat.m
+++ b/ios/RNSalesforceChat.m
@@ -58,7 +58,8 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(createPreChatData:(NSString *)agentLabel value:(NSString *)value
-                  isDisplayedToAgent:(BOOL)isDisplayedToAgent transcriptFields:(NSArray<NSString *> *)transcriptFields)
+                  isDisplayedToAgent:(BOOL)isDisplayedToAgent transcriptFields:(NSArray<NSString *> *)transcriptFields
+                  preChatDataKey:(NSString *)preChatDataKey)
 {
     SCSPrechatObject* prechatObject = [[SCSPrechatObject alloc] initWithLabel:agentLabel value:value];
     prechatObject.displayToAgent = isDisplayedToAgent;
@@ -67,26 +68,28 @@ RCT_EXPORT_METHOD(createPreChatData:(NSString *)agentLabel value:(NSString *)val
         NSMutableArray* receivedTranscriptFields = [transcriptFields mutableCopy];
         prechatObject.transcriptFields = receivedTranscriptFields;
     }
-    
-    prechatFields[agentLabel] = prechatObject;
+
+    prechatFields[preChatDataKey] = prechatObject;
 }
 
 RCT_EXPORT_METHOD(createEntityField:(NSString *)objectFieldName doCreate:(BOOL)doCreate doFind:(BOOL)doFind
-                  isExactMatch:(BOOL)isExactMatch keyChatUserDataToMap:(NSString *)keyChatUserDataToMap)
+                  isExactMatch:(BOOL)isExactMatch preChatDataKeyToMap:(NSString *)preChatDataKeyToMap
+                  entityFieldKey:(NSString *)entityFieldKey)
 {
-    if (prechatFields[keyChatUserDataToMap] != nil) {
+    if (prechatFields[preChatDataKeyToMap] != nil) {
+
         SCSPrechatEntityField* entityField = [[SCSPrechatEntityField alloc] initWithFieldName:objectFieldName
-                                                                                        label:keyChatUserDataToMap];
+                                                                                        label:prechatFields[preChatDataKeyToMap].label];
         entityField.doFind = doFind;
         entityField.doCreate = doCreate;
         entityField.isExactMatch = isExactMatch;
 
-        prechatEntities[objectFieldName] = entityField;
+        prechatEntities[entityFieldKey] = entityField;
     }
 }
 
 RCT_EXPORT_METHOD(createEntity:(NSString *)objectType linkToTranscriptField:(NSString *)linkToTranscriptField
-                  showOnCreate:(BOOL)showOnCreate keysEntityFieldToLink:(NSArray<NSString *> *)keysEntityFieldToMap)
+                  showOnCreate:(BOOL)showOnCreate entityFieldKeysToMap:(NSArray<NSString *> *)entityFieldKeysToMap)
 {
     SCSPrechatEntity* entity = [[SCSPrechatEntity alloc] initWithEntityName:objectType];
     entity.showOnCreate = showOnCreate;
@@ -95,7 +98,7 @@ RCT_EXPORT_METHOD(createEntity:(NSString *)objectType linkToTranscriptField:(NSS
         entity.saveToTranscript = linkToTranscriptField;
     }
 
-    for (id entityFieldKey in keysEntityFieldToMap) {
+    for (id entityFieldKey in entityFieldKeysToMap) {
         if (prechatEntities[entityFieldKey] != nil) {
             [entity.entityFieldsMaps addObject:prechatEntities[entityFieldKey]];
         }

--- a/lib/api/__tests__/salesforceChatAPI.test.js
+++ b/lib/api/__tests__/salesforceChatAPI.test.js
@@ -28,7 +28,8 @@ describe("SalesforceChatAPI", () => {
       agentLabel: "someLabel",
       value: "someValue",
       isDisplayedToAgent: true,
-      transcriptFields: ["someTranscriptField"]
+      transcriptFields: ["someTranscriptField"],
+      preChatDataKey: "somePreChatDataKey"
     };
 
     mockParamCreateEntityField = {
@@ -36,14 +37,15 @@ describe("SalesforceChatAPI", () => {
       doCreate: false,
       doFind: true,
       isExactMatch: true,
-      keyChatUserDataToMap: ["someKeyField"],
+      preChatDataKeyToMap: "somePreChatDataKey",
+      entityFieldKey: "someEntityFieldKey"
     };
 
     mockParamCreateEntity = {
       objectType: "someObjectType",
       linkToTranscriptField: "someTranscriptField",
       showOnCreate: false,
-      keysEntityFieldToMap: ["someKeyField"],
+      entityFieldKeysToMap: ["someEntityFieldKey"],
     };
 
     mockParamConfigureChat = {
@@ -63,13 +65,15 @@ describe("SalesforceChatAPI", () => {
         "someLabel",
         "someValue",
         true,
-        ["someTranscriptField"]
+        ["someTranscriptField"],
+        "somePreChatDataKey"
       );
 
       mockParamCreatePreChatData = {
         agentLabel: "someLabel",
         isDisplayedToAgent: true,
-        transcriptFields: ["someTranscriptField"]
+        transcriptFields: ["someTranscriptField"],
+        preChatDataKey: "somePreChatDataKey"
       }
 
       await salesforceChatAPI.createPreChatData(mockParamCreatePreChatData);
@@ -78,13 +82,15 @@ describe("SalesforceChatAPI", () => {
         "someLabel",
         null,
         true,
-        ["someTranscriptField"]
+        ["someTranscriptField"],
+        "somePreChatDataKey"
       );
 
       mockParamCreatePreChatData = {
         agentLabel: "someLabel",
         value: "someValue",
         isDisplayedToAgent: true,
+        preChatDataKey: "somePreChatDataKey"
       }
 
       await salesforceChatAPI.createPreChatData(mockParamCreatePreChatData);
@@ -94,6 +100,7 @@ describe("SalesforceChatAPI", () => {
         "someValue",
         true,
         null,
+        "somePreChatDataKey"
       );
     });
 
@@ -128,6 +135,14 @@ describe("SalesforceChatAPI", () => {
         salesforceChatAPI.createPreChatData(mockParamCreatePreChatData)
       ).rejects.toThrowError(new Error("required field isDisplayedToAgent"));
     });
+
+    it("throws an error when calling createPreChatData with null preChatDataKey", async () => {
+      mockParamCreatePreChatData.preChatDataKey = null;
+
+      await expect(
+        salesforceChatAPI.createPreChatData(mockParamCreatePreChatData)
+      ).rejects.toThrowError(new Error("required field preChatDataKey"));
+    });
   });
 
   describe("createEntityField", () => {
@@ -136,27 +151,30 @@ describe("SalesforceChatAPI", () => {
 
       expect(mockCreateEntityField).toHaveBeenCalledWith(
         "someObjectFieldName",
-        true,
         false,
         true,
-        ["someKeyField"]
+        true,
+        "somePreChatDataKey",
+        "someEntityFieldKey"
       );
 
       mockParamCreateEntityField = {
         objectFieldName: "someObjectFieldName",
-        doFind: true,
         doCreate: false,
-        isExactMatch: true
+        doFind: true,
+        isExactMatch: true,
+        entityFieldKey: "someEntityFieldKey"
       }
 
       await salesforceChatAPI.createEntityField(mockParamCreateEntityField);
 
       expect(mockCreateEntityField).toHaveBeenCalledWith(
         "someObjectFieldName",
-        true,
         false,
         true,
-        null
+        true,
+        null,
+        "someEntityFieldKey"
       );
     });
 
@@ -223,6 +241,14 @@ describe("SalesforceChatAPI", () => {
         salesforceChatAPI.createEntityField(mockParamCreateEntityField)
       ).rejects.toThrowError(new Error("required field isExactMatch"));
     });
+
+    it("throws an error when calling createEntityField with null entityFieldKey", async () => {
+      mockParamCreateEntityField.entityFieldKey = null;
+
+      await expect(
+        salesforceChatAPI.createEntityField(mockParamCreateEntityField)
+      ).rejects.toThrowError(new Error("required field entityFieldKey"));
+    });
   });
 
   describe("createEntity", () => {
@@ -233,7 +259,7 @@ describe("SalesforceChatAPI", () => {
         "someObjectType",
         "someTranscriptField",
         false,
-        ["someKeyField"]
+        ["someEntityFieldKey"]
       );
 
       mockParamCreateEntity = {

--- a/lib/api/__tests__/salesforceChatAPI.test.js
+++ b/lib/api/__tests__/salesforceChatAPI.test.js
@@ -33,8 +33,8 @@ describe("SalesforceChatAPI", () => {
 
     mockParamCreateEntityField = {
       objectFieldName: "someObjectFieldName",
-      doFind: true,
       doCreate: false,
+      doFind: true,
       isExactMatch: true,
       keyChatUserDataToMap: ["someKeyField"],
     };

--- a/lib/api/interfaces/ChatEntity.ts
+++ b/lib/api/interfaces/ChatEntity.ts
@@ -2,5 +2,5 @@ export interface ChatEntity {
   objectType: string;
   linkToTranscriptField?: string;
   showOnCreate: boolean;
-  keysEntityFieldToMap?: string[];
+  entityFieldKeysToMap?: string[];
 }

--- a/lib/api/interfaces/ChatEntityField.ts
+++ b/lib/api/interfaces/ChatEntityField.ts
@@ -3,5 +3,6 @@ export interface ChatEntityField {
   doCreate: boolean;
   doFind: boolean;
   isExactMatch: boolean;
-  keyChatUserDataToMap?: string;
+  preChatDataKeyToMap?: string;
+  entityFieldKey: string;
 }

--- a/lib/api/interfaces/PreChatData.ts
+++ b/lib/api/interfaces/PreChatData.ts
@@ -3,4 +3,5 @@ export interface PreChatData {
   value?: string;
   isDisplayedToAgent: boolean;
   transcriptFields?: string[];
+  preChatDataKey: string;
 }

--- a/lib/api/salesforceChatAPI.js
+++ b/lib/api/salesforceChatAPI.js
@@ -13,13 +13,22 @@ export default class SalesforceChatAPI {
     return param === undefined || param === null;
   }
 
-  async createPreChatData({ agentLabel, value, isDisplayedToAgent, transcriptFields }) {
+  async createPreChatData({ 
+    agentLabel, 
+    value, 
+    isDisplayedToAgent, 
+    transcriptFields, 
+    preChatDataKey
+  }) {
     
     if (!agentLabel) {
       this.throwRequiredFieldError("agentLabel");
     }
     if (this.isInvalidBooleanParam(isDisplayedToAgent)) {
       this.throwRequiredFieldError("isDisplayedToAgent");
+    }
+    if (!preChatDataKey) {
+      this.throwRequiredFieldError("preChatDataKey");
     }
 
     if (!value) value = null
@@ -29,7 +38,8 @@ export default class SalesforceChatAPI {
       agentLabel,
       value,
       isDisplayedToAgent,
-      transcriptFields
+      transcriptFields,
+      preChatDataKey
     );
   }
 
@@ -38,7 +48,8 @@ export default class SalesforceChatAPI {
     doCreate,
     doFind,
     isExactMatch,
-    keyChatUserDataToMap
+    preChatDataKeyToMap,
+    entityFieldKey
   }) {
     if (!objectFieldName) this.throwRequiredFieldError("objectFieldName");
     
@@ -51,15 +62,19 @@ export default class SalesforceChatAPI {
     if (this.isInvalidBooleanParam(isExactMatch)) {
       this.throwRequiredFieldError("isExactMatch");
     }
+    if (!entityFieldKey) {
+      this.throwRequiredFieldError("entityFieldKey");
+    }
 
-    if (!keyChatUserDataToMap) keyChatUserDataToMap = null
+    if (!preChatDataKeyToMap) preChatDataKeyToMap = null
 
     this.salesforceChat.createEntityField(
       objectFieldName,
       doCreate,
       doFind,
       isExactMatch,
-      keyChatUserDataToMap
+      preChatDataKeyToMap,
+      entityFieldKey,
     );
   }
 
@@ -67,7 +82,7 @@ export default class SalesforceChatAPI {
     objectType,
     linkToTranscriptField,
     showOnCreate,
-    keysEntityFieldToMap
+    entityFieldKeysToMap
   }) {
     if (!objectType) this.throwRequiredFieldError("objectType");
     if (this.isInvalidBooleanParam(showOnCreate)) {
@@ -75,13 +90,13 @@ export default class SalesforceChatAPI {
     }
 
     if (!linkToTranscriptField) linkToTranscriptField = null
-    if (!keysEntityFieldToMap) keysEntityFieldToMap = null
+    if (!entityFieldKeysToMap) entityFieldKeysToMap = null
 
     this.salesforceChat.createEntity(
       objectType,
       linkToTranscriptField,
       showOnCreate,
-      keysEntityFieldToMap
+      entityFieldKeysToMap
     );
   }
 

--- a/lib/api/salesforceChatAPI.js
+++ b/lib/api/salesforceChatAPI.js
@@ -35,17 +35,18 @@ export default class SalesforceChatAPI {
 
   async createEntityField({
     objectFieldName,
-    doFind,
     doCreate,
+    doFind,
     isExactMatch,
     keyChatUserDataToMap
   }) {
     if (!objectFieldName) this.throwRequiredFieldError("objectFieldName");
-    if (this.isInvalidBooleanParam(doFind)) {
-      this.throwRequiredFieldError("doFind");
-    }
+    
     if (this.isInvalidBooleanParam(doCreate)) {
       this.throwRequiredFieldError("doCreate");
+    }
+    if (this.isInvalidBooleanParam(doFind)) {
+      this.throwRequiredFieldError("doFind");
     }
     if (this.isInvalidBooleanParam(isExactMatch)) {
       this.throwRequiredFieldError("isExactMatch");
@@ -55,8 +56,8 @@ export default class SalesforceChatAPI {
 
     this.salesforceChat.createEntityField(
       objectFieldName,
-      doFind,
       doCreate,
+      doFind,
       isExactMatch,
       keyChatUserDataToMap
     );


### PR DESCRIPTION
## Types of changes

- Fix

## Description of the proposed changes

- Since different `EntityField` objects can have the same `fieldName`, the way the library's native code was creating these objects caused `EntityFields` to be overwritten when creating more than one with the same `fieldName`. This problem was solved by introducing exclusive keys for each object, AKA the `entityFieldKey`.  The `preChatDataKey` for `PreChatData` was created to keep a pattern and also avoid this kind of problem in the future.

- Fix the params `doFind` and `doCreate` of `createPreChatData` being passed to the native side in the wrong order.
