### PR TITLE
sets defaultToMinimized to false for iOS

### DIFF
--- a/ios/RNSalesforceChat.m
+++ b/ios/RNSalesforceChat.m
@@ -144,6 +144,7 @@ RCT_EXPORT_METHOD(configureChat:(NSString *)orgId buttonId:(NSString *)buttonId 
     if (visitorName != nil) chatConfiguration.visitorName = visitorName;
     chatConfiguration.prechatFields = [prechatFields allValues];
     chatConfiguration.prechatEntities = entities;
+    chatConfiguration.defaultToMinimized = false;
 }
 
 RCT_EXPORT_METHOD(openChat:(RCTResponseSenderBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback)


### PR DESCRIPTION
## Types of changes

_Include the types of changes_

- ~Bugfix~
- ~Chore~
- New feature
- ~Refactoring~
- ~Release~
- ~Unit tests~

## Reason for the changes

Matches the behavior of android to launch the chat in maximized state

## Description of the proposed changes

Sets `defaultToMinimized`  to false on iOS so the chat launches in the maximized state when `openChat` is called

I'd understand if the preference would be to have this as an optional property of the `ChatConfig` interface but since android was hardcoded as false and for our use case, we'd prefer the chat to launch similarly on iOS, I've added it directly to `RNSalesforceChat.m`

## Screenshots
N/A
